### PR TITLE
Updated ArchiveDir to Persist File Headers

### DIFF
--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -72,7 +72,12 @@ func (a *ZipArchiver) ArchiveDir(indirname string) error {
 		if err != nil {
 			return fmt.Errorf("error relativizing file for archival: %s", err)
 		}
-		f, err := a.writer.Create(relname)
+		fh, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return fmt.Errorf("error creating file header: %s", err)
+		}
+		fh.Name = relname
+		f, err := a.writer.CreateHeader(fh)
 		if err != nil {
 			return fmt.Errorf("error creating file inside archive: %s", err)
 		}


### PR DESCRIPTION
This PR addresses the issue reported here (https://github.com/terraform-providers/terraform-provider-archive/issues/8) where the file attributes are stripped when creating an archive from a source directory.

In this PR we replace the use of `writer.Create` with `write.CreateHeader` using the file header that is already present in the method.