### PR TITLE
Updated ArchiveFile to persist file headers

### DIFF
--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -57,6 +57,7 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 		return fmt.Errorf("error creating file header: %s", err)
 	}
 	fh.Name = fi.Name()
+	fh.Method = zip.Deflate
 
 	f, err := a.writer.CreateHeader(fh)
 	if err != nil {
@@ -94,6 +95,7 @@ func (a *ZipArchiver) ArchiveDir(indirname string) error {
 			return fmt.Errorf("error creating file header: %s", err)
 		}
 		fh.Name = relname
+		fh.Method = zip.Deflate
 		f, err := a.writer.CreateHeader(fh)
 		if err != nil {
 			return fmt.Errorf("error creating file inside archive: %s", err)

--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -47,7 +47,24 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 		return err
 	}
 
-	return a.ArchiveContent(content, fi.Name())
+	if err := a.open(); err != nil {
+		return err
+	}
+	defer a.close()
+
+	fh, err := zip.FileInfoHeader(fi)
+	if err != nil {
+		return fmt.Errorf("error creating file header: %s", err)
+	}
+	fh.Name = fi.Name()
+
+	f, err := a.writer.CreateHeader(fh)
+	if err != nil {
+		return fmt.Errorf("error creating file inside archive: %s", err)
+	}
+
+	_, err = f.Write(content)
+	return err
 }
 
 func (a *ZipArchiver) ArchiveDir(indirname string) error {


### PR DESCRIPTION
Same as #9, but for `ArchiveFile`.

With this, I am able to use `archive_file` to zip a single go binary, deploy it to Lambda, and run it successfully. I am using MacOS.