### PR TITLE
Forcing directory separator to be '/' (cross-platform consistency)

### DIFF
--- a/archive/archiver.go
+++ b/archive/archiver.go
@@ -5,7 +5,10 @@ import (
 	"os"
 )
 
+type FilenameModifier func(filename string) string
+
 type Archiver interface {
+	SetFilenameModifier(modifier FilenameModifier)
 	ArchiveContent(content []byte, infilename string) error
 	ArchiveFile(infilename string) error
 	ArchiveDir(indirname string, excludes []string) error

--- a/archive/data_source_archive_file.go
+++ b/archive/data_source_archive_file.go
@@ -21,23 +21,23 @@ func dataSourceFile() *schema.Resource {
 		Read: dataSourceFileRead,
 
 		Schema: map[string]*schema.Schema{
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"source": &schema.Schema{
+			"source": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"content": &schema.Schema{
+						"content": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-						"filename": &schema.Schema{
+						"filename": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
@@ -53,31 +53,31 @@ func dataSourceFile() *schema.Resource {
 					return hashcode.String(buf.String())
 				},
 			},
-			"source_content": &schema.Schema{
+			"source_content": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"source_file", "source_dir"},
 			},
-			"source_content_filename": &schema.Schema{
+			"source_content_filename": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"source_file", "source_dir"},
 			},
-			"source_file": &schema.Schema{
+			"source_file": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"source_content", "source_content_filename", "source_dir"},
 			},
-			"source_dir": &schema.Schema{
+			"source_dir": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"source_content", "source_content_filename", "source_file"},
 			},
-			"excludes": &schema.Schema{
+			"excludes": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ForceNew:      true,
@@ -86,28 +86,28 @@ func dataSourceFile() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"output_path": &schema.Schema{
+			"output_path": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"output_size": &schema.Schema{
+			"output_size": {
 				Type:     schema.TypeInt,
 				Computed: true,
 				ForceNew: true,
 			},
-			"output_sha": &schema.Schema{
+			"output_sha": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				ForceNew:    true,
 				Description: "SHA1 checksum of output file",
 			},
-			"output_base64sha256": &schema.Schema{
+			"output_base64sha256": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				ForceNew:    true,
 				Description: "Base64 Encoded SHA256 checksum of output file",
 			},
-			"output_md5": &schema.Schema{
+			"output_md5": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				ForceNew:    true,
@@ -171,6 +171,8 @@ func archive(d *schema.ResourceData) error {
 		return fmt.Errorf("archive type not supported: %s", archiveType)
 	}
 
+	archiver.SetFilenameModifier(filenameSeparatorModifier("/"))
+
 	if dir, ok := d.GetOk("source_dir"); ok {
 		if excludes, ok := d.GetOk("excludes"); ok {
 			excludeList := expandStringList(excludes.([]interface{}))
@@ -227,4 +229,21 @@ func genFileShas(filename string) (string, string, string, error) {
 	md5Sum := hex.EncodeToString(md5.Sum(nil))
 
 	return sha1, sha256base64, md5Sum, nil
+}
+
+func filenameSeparatorModifier(sep string) FilenameModifier {
+	return func(filename string) string {
+		var buffer bytes.Buffer
+		for _, ch := range filename {
+			s := string(ch)
+			switch s {
+			case "/":
+				s = sep
+			case "\\":
+				s = sep
+			}
+			buffer.WriteString(s)
+		}
+		return buffer.String()
+	}
 }


### PR DESCRIPTION
## Problem

On a windows machine, when trying to zip the contents of a directory, the files will be emitted with a `\` as the directory separator.

When trying to package a nodejs function with `node_modules` and upload to AWS Lambda, I kept getting error messages that a particular module could not be found when doing `require('...')`.

## Solution

~~This PR introduces the ability to specify `dir_separator = "/"`.~~
This PR enforces every directory separator to be `/`.
After compiling and running against my existing terraform plan, the lambda works as expected.

Additionally, this ensures that cross-platform terraform plans with the same content do not cause differences in the terraform plan (as a result of a different output hash).


