### PR TITLE
prevent panic if filepath.Walk() path not found

### DIFF
--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -97,6 +97,10 @@ func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
 
 	return filepath.Walk(indirname, func(path string, info os.FileInfo, err error) error {
 
+		if err != nil {
+			return fmt.Errorf("error encountered during file walk: %s", err)
+		}
+
 		relname, err := filepath.Rel(indirname, path)
 		if err != nil {
 			return fmt.Errorf("error relativizing file for archival: %s", err)


### PR DESCRIPTION
Prevents the panic seen in #5