### PR TITLE
Add excludes option to document.

### DIFF
--- a/website/docs/d/archive_file.md
+++ b/website/docs/d/archive_file.md
@@ -67,6 +67,8 @@ NOTE: One of `source`, `source_content_filename` (with `source_content`), `sourc
 
 * `source` - (Optional) Specifies attributes of a single source file to include into the archive.
 
+* `excludes` - (Optional) Specifies a list of file to exclude.
+
 The `source` block supports the following:
 
 * `content` - (Required) Add this content to the archive with `filename` as the filename.


### PR DESCRIPTION
I'm sorry for my poor English...

I created a pull request because the excludes option was missing from the [document](https://www.terraform.io/docs/providers/archive/d/archive_file.html).

If you intentionally didn't list the excludes option in the [document](https://www.terraform.io/docs/providers/archive/d/archive_file.html), close this pull request.