### PR TITLE
website: remove unnecessary quotes

### DIFF
--- a/website/archive.erb
+++ b/website/archive.erb
@@ -10,7 +10,7 @@
       </li>
 
       <li<%= sidebar_current("docs-archive-datasource") %>>
-      <a href="#">"Data Sources"</a>
+      <a href="#">Data Sources</a>
         <ul class="nav nav-visible">
           <li<%= sidebar_current("docs-archive-datasource-archive-file") %>>
             <a href="/docs/providers/archive/d/archive_file.html">archive_file</a>


### PR DESCRIPTION
Previous PR #52 added unnecessary quotes to the docs navigation

<img src="https://user-images.githubusercontent.com/6362111/68048112-e1d6c000-fcad-11e9-8721-016ab3c3f43c.png" height=300px>
